### PR TITLE
Add corn as a PHONY target (predicative branch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: coq clean
+.PHONY: coq clean corn
 
 coq: Makefile.coq
 	$(MAKE) -f Makefile.coq


### PR DESCRIPTION
Otherwise, `make corn` won't always run `make` in the `corn` directory.