### PR TITLE
Fix after decide equality is able to keep proofs in arguments in Prop.

### DIFF
--- a/src/Types/Finite.v
+++ b/src/Types/Finite.v
@@ -389,11 +389,7 @@ Theorem eq_dec {A : Type} : T A -> forall a b : A, {a = b} + {a <> b}.
 Proof.
 intros finite.
 induction finite; intros; try (decide equality).
-- destruct a, b. 
-  + destruct t, t0. auto. 
-  + destruct t. right. congruence.
-  + destruct t. right. congruence.
-  + pose proof (IHfinite a a0). destruct H; [left | right]; congruence.
+- destruct t, a0. auto.
 - eapply Iso.eq_dec; eassumption.
 Qed.
 


### PR DESCRIPTION
Hi,

Coq 8.7 shall come with a fix to `decide equality` which makes it working better (even though more progresses are expectable). However, this improvement breaks `topology`.

The attached patch allows to compile `topology` with 8.7. However, the fix is not compatible with 8.6. May I let you decide if you prefer preparing your own patch so as to be compatible over both 8.6 and 8.7 at the same time, or whether you prefer to have disjoint versions.

Note that we can also provide various different ways to support compatibility over different versions. For instance, the question of possibly providing `Set Version 8.6.`/`Unset Version 8.6.` commands around parts of code that would work only in 8.6 has been considered, though no final decision has been taken yet. Don't hesitate to tell your point of view as a user, if you have one.
