### PR TITLE
Coq now prunes phantom universes (backward-compatible patch).

### DIFF
--- a/src/FormTopC/FormTop.v
+++ b/src/FormTopC/FormTop.v
@@ -557,7 +557,10 @@ eapply t_Proper@{A P I API API}. 2: apply Localized_formtop.
 symmetry. apply cov_equiv.
 Qed.
 
+Universes API'.
+(* In Coq >= 8.8 more useless universes get pruned. *)
 Global Instance GCovL_formtop: t (@toPSL@{A P I} A)
-  := GCovL_formtop_UMore@{API API}.
+  := ltac:(first [exact GCovL_formtop_UMore@{API API}|
+                  exact GCovL_formtop_UMore@{API API API'}]).
 
 End Localize.

--- a/src/FormTopC/FormalSpace.v
+++ b/src/FormTopC/FormalSpace.v
@@ -25,7 +25,7 @@ Global Instance IGT_PreO@{A P I API}
   (X : IGt@{A P I API}) : PreO.t (le X) := IGPO X.
 Global Instance IGTFT@{A P I API API'} (X : IGt@{A P I API}) : 
   FormTop.t (toPSL (IGS X)) :=
-  FormTop.GCovL_formtop@{A P I API} _.
+  FormTop.GCovL_formtop@{A P I API API'} _.
 
 
 Record t@{A P I} : Type :=

--- a/src/FormTopC/Metric.v
+++ b/src/FormTopC/Metric.v
@@ -238,8 +238,10 @@ Qed.
 
 Set Printing Universes.
 
+(* In Coq >= 8.8 more useless universes get pruned. *)
 Local Instance MPos@{API'} : FormTop.gtPos MetricPS
-  := MPos_MUniv@{API' API' API'}.
+  := ltac:(first [exact MPos_MUniv@{API' API' API'}|
+                  exact MPos_MUniv@{API' API' P P P P P API' P P P P P}]).
 
 Definition Metric@{API'} : IGt@{A P I API'} :=
   {| IGS := MetricPS


### PR DESCRIPTION
Sorry, the previous patch wasn't compatible with Coq 8.7.