### PR TITLE
Get rid of ' to provide compatibility with coq/coq#6155

### DIFF
--- a/src/clement/SmallPowers.v
+++ b/src/clement/SmallPowers.v
@@ -69,7 +69,7 @@ Proof.
   edestruct (power_large_util'' (Pos.to_nat (qn * epsilond))) as [ n h ].
   - apply Pos2Nat.is_pos.
   - eexists (S n).
-    rewrite <- (Qmult_lt_l _ _ (/ (' qn # qd))), Qmult_assoc, (Qmult_comm _ (' qn # qd)), Qmult_inv_r, Qmult_1_l. 
+    rewrite <- (Qmult_lt_l _ _ (/ (Zpos qn # qd))), Qmult_assoc, (Qmult_comm _ (Zpos qn # qd)), Qmult_inv_r, Qmult_1_l. 
     unfold Qlt, Qinv in *; simpl in *; unfold Z.lt.
     rewrite <- Pos2Z.inj_compare, Pos2Nat.inj_compare, <- nat_compare_lt, !Pos2Nat.inj_mul, SuccNat2Pos.id_succ, <- !Pos2Nat.inj_mul.
     eassumption.


### PR DESCRIPTION
This change is backwards compatible.