### PR TITLE
Fix #18: `cofix` tactic without a name is deprecated.

### DIFF
--- a/src/FormTopC/NatInfty.v
+++ b/src/FormTopC/NatInfty.v
@@ -179,7 +179,7 @@ Proof.
 destruct (IGCont.pt_here ptx).
 induction a.
 Focus 2. apply Now. apply tt.
-generalize dependent n. cofix.
+generalize dependent n. cofix pt_to_Partial.
 intros.
 pose proof (IGCont.pt_cov ptx 
   (MoreThan n) (MoreThan n) (IxNext n) 


### PR DESCRIPTION
Backward compatible fix for bug #18.