### PR TITLE
Adapt to coq/coq#8850 (private universes for opaque constants) 

### DIFF
--- a/src/FormTopC/FormTop.v
+++ b/src/FormTopC/FormTop.v
@@ -243,7 +243,7 @@ Definition toPSUL@{} : PreSpace.t@{A P I} :=
 
 Context {PO : PreO.t@{A P} (le A)}.
 
-Lemma Lmore_MUniv a U : GCov a U -> GCovL a U.
+Lemma Lmore@{} a U : GCov a U -> GCovL a U.
 Proof.
 intros aU. induction aU.
 - apply glrefl. assumption.
@@ -254,10 +254,7 @@ intros aU. induction aU.
   assumption.
 Qed.
 
-Definition Lmore@{API} a U : GCov a U -> GCovL a U
-  := Lmore_MUniv@{API} a U.
-
-Lemma gmonotone_MUniv (a : A) (U V : Open@{A P} A) :
+Lemma gmonotone@{} (a : A) (U V : Open@{A P} A) :
   U ⊆ V -> GCov a U -> GCov a V.
 Proof.
 intros UV aU. induction aU.
@@ -267,11 +264,7 @@ intros UV aU. induction aU.
 - eapply ginfinity. eauto.
 Qed.
 
-Definition gmonotone@{API} (a : A) (U V : Open@{A P} A) :
-  U ⊆ V -> GCov a U -> GCov a V
-  := gmonotone_MUniv@{API} a U V.
-
-Lemma gmonotoneL_MUniv a (U V : Open A) :
+Lemma gmonotoneL@{} a (U V : Open A) :
   U ⊆ V -> GCovL a U -> GCovL a V.
 Proof.
 intros UV aU. induction aU.
@@ -279,10 +272,6 @@ intros UV aU. induction aU.
 - eapply glle_left. eassumption. apply IHaU. assumption.
 - eapply gle_infinity. eassumption. intros. apply X; eassumption.
 Qed.
-
-Definition gmonotoneL@{API} a (U V : Open A) :
-  U ⊆ V -> GCovL a U -> GCovL a V
-  := gmonotoneL_MUniv@{API} a U V.
 
 Ltac equivalence := repeat (reflexivity || assumption || symmetry).
 
@@ -302,7 +291,7 @@ Qed.
 
 Definition gsubset_equiv@{API} (U V : Open A) : U === V
   -> forall a, GCov a U <--> GCov a V
-  := gsubset_equiv_MUniv@{API API API} U V.
+  := gsubset_equiv_MUniv@{API API} U V.
 
 Class gtPos@{} :=
   { gPos : Subset@{A P} A
@@ -499,7 +488,7 @@ Context {PO : PreO.t@{A P} (le A)}.
 
 
 
-Lemma Llocalized_UMore : localized@{A P I} Localized.
+Lemma Llocalized@{} : localized@{A P I} Localized.
 Proof.
 unfold localized.
 intros. destruct i. simpl in *.
@@ -512,9 +501,7 @@ apply Included_impl. intros. subst.
 split. exists x; reflexivity. exists c. reflexivity.
 assumption. reflexivity.
 Qed.
-
-Instance Llocalized@{} : localized Localized :=
-  Llocalized_UMore@{API API API}.
+Existing Instance Llocalized.
 
 Theorem cov_equiv_UMore : GCovL A ==== GCov Localized.
 Proof.
@@ -551,16 +538,12 @@ Proof.
 apply GCov_formtop.
 Qed.
 
-Theorem GCovL_formtop_UMore : t (toPSL@{A P I} A).
+Theorem GCovL_formtop@{} : t (toPSL@{A P I} A).
 Proof.
 eapply t_Proper@{A P I API API}. 2: apply Localized_formtop.
 symmetry. apply cov_equiv.
 Qed.
 
-Universes API'.
-(* In Coq >= 8.8 more useless universes get pruned. *)
-Global Instance GCovL_formtop: t (@toPSL@{A P I} A)
-  := ltac:(first [exact GCovL_formtop_UMore@{API API}|
-                  exact GCovL_formtop_UMore@{API API API'}]).
+Global Existing Instance GCovL_formtop.
 
 End Localize.

--- a/src/FormTopC/FormalSpace.v
+++ b/src/FormTopC/FormalSpace.v
@@ -23,9 +23,9 @@ Record IGt@{A P I API} : Type :=
 
 Global Instance IGT_PreO@{A P I API} 
   (X : IGt@{A P I API}) : PreO.t (le X) := IGPO X.
-Global Instance IGTFT@{A P I API API'} (X : IGt@{A P I API}) : 
+Global Instance IGTFT@{A P I API} (X : IGt@{A P I API}) :
   FormTop.t (toPSL (IGS X)) :=
-  FormTop.GCovL_formtop@{A P I API API'} _.
+  FormTop.GCovL_formtop@{A P I API} _.
 
 
 Record t@{A P I} : Type :=
@@ -39,9 +39,9 @@ Local Open Scope FT.
 Delimit Scope loc_scope with loc.
 Local Open Scope loc.
 
-Definition fromIGt@{A P I API API'} (A : IGt@{A P I API}) : t@{A P I} :=
+Definition fromIGt@{A P I API} (A : IGt@{A P I API}) : t@{A P I} :=
   {| S := toPSL (IGS A)
-   ; isFT := IGTFT@{A P I API API'} A|}.
+   ; isFT := IGTFT@{A P I API} A|}.
 
 Coercion fromIGt : IGt >-> t.
 

--- a/src/FormTopC/Metric.v
+++ b/src/FormTopC/Metric.v
@@ -222,7 +222,7 @@ destruct (Qpos_smaller q) as [q' qq'].
 exists (m, q'). apply lt_ball_center. assumption.
 Qed. 
 
-Lemma MPos_MUniv : FormTop.gtPos MetricPS.
+Lemma MPos@{} : FormTop.gtPos MetricPS.
 Proof.
 apply gall_Pos. simpl. intros. destruct i.
 - simpl. exists (fst a, QposMinMax.Qpos_min q (snd a)).
@@ -235,13 +235,7 @@ apply gall_Pos. simpl. intros. destruct i.
   exists x. simpl. eapply lt_le_trans; eassumption.
   reflexivity.
 Qed.
-
-Set Printing Universes.
-
-(* In Coq >= 8.8 more useless universes get pruned. *)
-Local Instance MPos@{API'} : FormTop.gtPos MetricPS
-  := ltac:(first [exact MPos_MUniv@{API' API' API'}|
-                  exact MPos_MUniv@{API' API' P P P P P API' P P P P P}]).
+Local Existing Instance MPos.
 
 Definition Metric@{API'} : IGt@{A P I API'} :=
   {| IGS := MetricPS


### PR DESCRIPTION
Not backward compatible.
Alternatively we can [Unset Private Polymorphic Universes.]